### PR TITLE
Update package dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'nicolaslopezj:router-layer',
   summary: 'A layer for Meteor Routers',
-  version: '0.0.11',
+  version: '0.0.12',
   git: 'https://github.com/nicolaslopezj/meteor-router-layer'
 });
 

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
 
-  api.use(['meteor-platform', 'underscore']);
+  api.use(['meteor-base', 'tracker' , 'templating', 'check', 'underscore']);
 
   api.use(['iron:router@1.0.9', 'kadira:flow-router@2.1.1', 'kadira:blaze-layout@2.0.0', 'nicolaslopezj:reactive-templates@1.2.1'], { weak: true });
 


### PR DESCRIPTION
Hi, could you please merge this and possibly release it too?

The issue I had was that the dependency on `meteor-platform` itself has the package `fastclick` as a dependency. Which i wanted to get rid of because I want another package to handle the "fastclick" / touchevents - issue.

See here: https://github.com/JoeyAndres/meteor-ionic/issues/60

I'm trying to add Router-Layer to the aforementioned package (https://github.com/JoeyAndres/meteor-ionic/), which has the dependency to not have fast click - a nice twist, right? :)

It'd be great if you could merge this and possibly release this to atmosphere / the meteor package system.
