### PR TITLE
Add support for ostrio:flow-router-extra

### DIFF
--- a/flow-router.js
+++ b/flow-router.js
@@ -8,16 +8,39 @@ if (RouterLayer.router == 'flow-router') {
         if (options.reactiveTemplates) {
           Tracker.autorun(function() {
             if (options.layout) {
-              self.blazeLayout.render(ReactiveTemplates.get(options.layout), { content: ReactiveTemplates.get(options.template) });
-            } else {
-              self.blazeLayout.render(ReactiveTemplates.get(options.template));
+              if (Package['kadira:flow-router'] && Package['kadira:blaze-layout']) {
+                self.blazeLayout.render(ReactiveTemplates.get(options.layout), { content: ReactiveTemplates.get(options.template) });
+              }
+              else {
+                self.flowRouter.Renderer.render(ReactiveTemplates.get(options.layout), ReactiveTemplates.get(options.template));
+              }
+            }
+            else {
+              if (Package['kadira:flow-router'] && Package['kadira:blaze-layout']) {
+                self.blazeLayout.render(ReactiveTemplates.get(options.template));
+              }
+              else {
+                self.flowRouter.Renderer.render(ReactiveTemplates.get(options.template));
+              }
             }
           });
-        } else {
+        }
+        else {
           if (options.layout) {
-            self.blazeLayout.render(options.layout, { content: options.template });
-          } else {
-            self.blazeLayout.render(options.template);
+            if (Package['kadira:flow-router'] && Package['kadira:blaze-layout']) {
+              self.blazeLayout.render(options.layout, options.template);
+            }
+            else {
+              self.flowRouter.Renderer.render(options.layout, options.template);
+            }
+          }
+          else {
+            if (Package['kadira:flow-router'] && Package['kadira:blaze-layout']) {
+              self.blazeLayout.render(options.template);
+            }
+            else {
+              self.flowRouter.Renderer.render(options.template);
+            }
           }
         }
       }

--- a/flow-router.js
+++ b/flow-router.js
@@ -28,7 +28,7 @@ if (RouterLayer.router == 'flow-router') {
         else {
           if (options.layout) {
             if (Package['kadira:flow-router'] && Package['kadira:blaze-layout']) {
-              self.blazeLayout.render(options.layout, options.template);
+              self.blazeLayout.render(options.layout, { content: options.template });
             }
             else {
               self.flowRouter.Renderer.render(options.layout, options.template);

--- a/layer.js
+++ b/layer.js
@@ -18,22 +18,30 @@ if (_.has(Package, 'iron:router')) {
 }
 
 /**
- * Check if uses flow router
+ * Check if uses kadira:flow router
  */
-if (_.has(Package, 'kadira:flow-router') || _.has(Package, 'ostrio:flow-router-extra')) {
+if (_.has(Package, 'kadira:flow-router')) {
   RouterLayer.router = 'flow-router';
   if (!_.has(Package, 'kadira:blaze-layout')) {
-    throw new Meteor.Error('router-layer', 'If you use kadira:flow-router or ostrio:flow-router-extra you must add kadira:blaze-layout');
+    throw new Meteor.Error('router-layer', 'If you use kadira:flow-router you must add kadira:blaze-layout');
   }
-  RouterLayer.flowRouter = Package[_.has(Package, 'kadira:flow-router') ? 'kadira:flow-router' : 'ostrio:flow-router-extra'].FlowRouter;
+  RouterLayer.flowRouter = Package['kadira:flow-router'].FlowRouter;
   RouterLayer.blazeLayout = Package['kadira:blaze-layout'].BlazeLayout;
+}
+
+/**
+ * Check if uses ostrio:flow-router-extra
+ */
+if (_.has(Package, 'ostrio:flow-router-extra')) {
+  RouterLayer.router = 'flow-router';
+  RouterLayer.flowRouter = Package['ostrio:flow-router-extra'].FlowRouter;
 }
 
 /*
  * Throw a error if there is no route package
  */
 if (!RouterLayer.router) {
-  throw new Meteor.Error('router-layer', 'You must add iron:router or kadira:flow-router');
+  throw new Meteor.Error('router-layer', 'You must add iron:router, kadira:flow-router, or ostrio:flow-router-extra');
 }
 
 /**

--- a/layer.js
+++ b/layer.js
@@ -20,12 +20,12 @@ if (_.has(Package, 'iron:router')) {
 /**
  * Check if uses flow router
  */
-if (_.has(Package, 'kadira:flow-router')) {
+if (_.has(Package, 'kadira:flow-router') || _.has(Package, 'ostrio:flow-router-extra')) {
   RouterLayer.router = 'flow-router';
   if (!_.has(Package, 'kadira:blaze-layout')) {
-    throw new Meteor.Error('router-layer', 'If you use kadira:flow-router you must add kadira:blaze-layout');
+    throw new Meteor.Error('router-layer', 'If you use kadira:flow-router or ostrio:flow-router-extra you must add kadira:blaze-layout');
   }
-  RouterLayer.flowRouter = Package['kadira:flow-router'].FlowRouter;
+  RouterLayer.flowRouter = Package[_.has(Package, 'kadira:flow-router') ? 'kadira:flow-router' : 'ostrio:flow-router-extra'].FlowRouter;
   RouterLayer.blazeLayout = Package['kadira:blaze-layout'].BlazeLayout;
 }
 

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
 
   api.use(['meteor-platform', 'underscore']);
 
-  api.use(['iron:router@1.0.9', 'kadira:flow-router@2.1.1', 'ostrio:flow-router-extra@3.2.2', 'kadira:blaze-layout@2.0.0', 'nicolaslopezj:reactive-templates@1.2.1'], { weak: true });
+  api.use(['iron:router@1.0.9', 'kadira:flow-router@2.1.1', 'ostrio:flow-router-extra@3.3.0', 'kadira:blaze-layout@2.0.0', 'nicolaslopezj:reactive-templates@1.2.1'], { weak: true });
 
   api.addFiles([
     'layer.js',

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
 
   api.use(['meteor-platform', 'underscore']);
 
-  api.use(['iron:router@1.0.9', 'kadira:flow-router@2.1.1', 'kadira:blaze-layout@2.0.0', 'nicolaslopezj:reactive-templates@1.2.1'], { weak: true });
+  api.use(['iron:router@1.0.9', 'kadira:flow-router@2.1.1', 'ostrio:flow-router-extra@3.2.2', 'kadira:blaze-layout@2.0.0', 'nicolaslopezj:reactive-templates@1.2.1'], { weak: true });
 
   api.addFiles([
     'layer.js',


### PR DESCRIPTION
Greetings, @nicolaslopezj.

The project I currently am working on uses `scorpiusjs:scorpius`, which is a dependent of this package. The version of FlowRouter this package depends on, `kadira:flow-router`, has been forked by another group. Many members of the Meteor community are beginning to use the said fork `ostrio:flow-router-extra` version of FlowRouter.

As no tests were provided, I was only able to test this with my project, which depends on `ostrio:flow-router-extra` and neither `kadira:flow-router` nor `kadira:blaze-layout`. Installing my fork as a local package and running the project resulted in no errors.

I thank you for considering this matter.